### PR TITLE
r-universe badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@
 
 [![CRAN
 version](https://www.r-pkg.org/badges/version/tinyplot.png)](https://CRAN.R-project.org/package=tinyplot)
-[![R-universe status
-badge](https://grantmcdermott.r-universe.dev/badges/tinyplot)](https://grantmcdermott.r-universe.dev)
+<a href="https://grantmcdermott.r-universe.dev"><img src="https://grantmcdermott.r-universe.dev/badges/tinyplot" class="img-fluid" alt="R-universe status badge"></a>
 [![R-CMD-check](https://github.com/grantmcdermott/tinyplot/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/grantmcdermott/tinyplot/actions/workflows/R-CMD-check.yaml)
 [![Docs](https://img.shields.io/badge/docs-homepage-blue.svg)](https://grantmcdermott.com/tinyplot/index.html)
 <!-- badges: end -->

--- a/README.qmd
+++ b/README.qmd
@@ -15,7 +15,7 @@ knitr::opts_chunk$set(
 
 <!-- badges: start -->
 [![CRAN version](https://www.r-pkg.org/badges/version/tinyplot)](https://CRAN.R-project.org/package=tinyplot)
-[![R-universe status badge](https://grantmcdermott.r-universe.dev/badges/tinyplot)](https://grantmcdermott.r-universe.dev)
+<a href="https://grantmcdermott.r-universe.dev"><img src="https://grantmcdermott.r-universe.dev/badges/tinyplot" class="img-fluid" alt="R-universe status badge"></a>
 [![R-CMD-check](https://github.com/grantmcdermott/tinyplot/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/grantmcdermott/tinyplot/actions/workflows/R-CMD-check.yaml)
 [![Docs](https://img.shields.io/badge/docs-homepage-blue.svg)](https://grantmcdermott.com/tinyplot/index.html)
 <!-- badges: end -->


### PR DESCRIPTION
Quarto inserts .png automatically when using the `[]()` syntax for images and when there is no extension to the image path. R-universe badges are hosted on a website with a link without extension.

Here, we just use normal HTML syntax to avoid adding .png.